### PR TITLE
fix package.sh --chart-repo option

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -36,7 +36,7 @@ done
 
 mv *.tgz packages/.
 rm packages/.gitkeep
-cr index --owner bcgov --git-repo helm-charts --package-path ./packages --index-path ./docs/index.yaml --charts-repo https://github.com/bcgov/helm-charts/releases
+cr index --owner bcgov --git-repo helm-charts --package-path ./packages --index-path ./docs/index.yaml --charts-repo https://bcgov.github.io/helm-charts
 touch packages/.gitkeep
 
 git add docs


### PR DESCRIPTION
The `--chart-repo` option should be pointing at the helm chart repository, not the git repo.
I suspect that this is the reason why the charts previous versions get overridden when running the release script.