### PR TITLE
Make oidc.logout a configurable value

### DIFF
--- a/charts/ckan-ui/Chart.yaml
+++ b/charts/ckan-ui/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deployment of the bcgov ckan-ui
 name: ckan-ui
-version: 0.2.7
+version: 0.2.8

--- a/charts/ckan-ui/templates/config-map.yaml
+++ b/charts/ckan-ui/templates/config-map.yaml
@@ -19,6 +19,7 @@ data:
         "userInfoURL": {{ .Values.oidc.userInfoURL | quote }},
         "clientID": {{ .Values.oidc.clientID | quote }},
         "callbackURL": {{ .Values.oidc.callbackURL | quote }},
+        "logout": {{ .Values.oidc.logout | quote }},
         "scope": "openid profile offline_access"
       },
       "pow": {

--- a/charts/ckan-ui/values.yaml
+++ b/charts/ckan-ui/values.yaml
@@ -72,6 +72,7 @@ oidc:
   clientID: "clientId"
   clientSecret: "clientSecret"
   callbackURL: "callbackUrl"
+  logout: ""
 
 pow:
   past_orders_nbr: 0


### PR DESCRIPTION
For bcgov/ckan-ui#542, the oidc.logout parameter is needed. It allows deployments to specify which keycloak endpoint is used to log a user out. This PR adds that parameter.