### PR TITLE
Added redisHost and redisPort values

### DIFF
--- a/charts/ckan-ui/Chart.yaml
+++ b/charts/ckan-ui/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deployment of the bcgov ckan-ui
 name: ckan-ui
-version: 0.2.9
+version: 0.2.10

--- a/charts/ckan-ui/templates/config-map.yaml
+++ b/charts/ckan-ui/templates/config-map.yaml
@@ -13,6 +13,9 @@ data:
       "classicUi": {{ .Values.classicUi | quote}},
       "aboutPageUrl": {{ .Values.aboutPageUrl | quote }},
 
+      "redisHost": {{ .Values.redisHost | quote }},
+      "redisPort": {{ .Values.redisPort | quote }},
+
       "oidc": {
         "issuer": {{ .Values.oidc.issuer | quote }},
         "authorizationURL": {{ .Values.oidc.authorizationURL | quote }},

--- a/charts/ckan-ui/templates/config-map.yaml
+++ b/charts/ckan-ui/templates/config-map.yaml
@@ -17,6 +17,7 @@ data:
 
       "redisHost": {{ .Values.redisHost | quote }},
       "redisPort": {{ .Values.redisPort | quote }},
+      "redisPassword": {{ .Values.redisPassword | quote }},
 
       "oidc": {
         "issuer": {{ .Values.oidc.issuer | quote }},

--- a/charts/ckan-ui/templates/config-map.yaml
+++ b/charts/ckan-ui/templates/config-map.yaml
@@ -5,6 +5,8 @@ metadata:
 data:
   prod.json: |-
     {
+      "secretsPath": {{ .Values.secretsPath | quote }},
+
       "solr": {{ .Values.solr | quote }},
       "solrCore": {{ .Values.solrCore | quote }},
       "ckan": {{ .Values.ckan | quote }},

--- a/charts/ckan-ui/values.yaml
+++ b/charts/ckan-ui/values.yaml
@@ -65,6 +65,9 @@ aboutPageUrl: "https://raw.githubusercontent.com/bcgov/ckan-ui/pages/pages/about
 sessionSecret: "secret"
 classicUi: "https://127.0.0.1:5000"
 
+redisHost: ""
+redisPort: ""
+
 oidc:
   issuer: "issuer"
   authorizationURL: "authurl"

--- a/charts/ckan-ui/values.yaml
+++ b/charts/ckan-ui/values.yaml
@@ -56,6 +56,9 @@ repo:
   url: https://github.com/bcgov/ckan-ui
 webhookKey: 12345678
 
+
+secretsPath: ""
+
 #you must override these
 solr: "http://127.0.0.1:8983/solr"
 solrCore: "ckan"

--- a/charts/ckan-ui/values.yaml
+++ b/charts/ckan-ui/values.yaml
@@ -70,6 +70,7 @@ classicUi: "https://127.0.0.1:5000"
 
 redisHost: ""
 redisPort: ""
+redisPassword: ""
 
 oidc:
   issuer: "issuer"


### PR DESCRIPTION
To support https://github.com/bcgov/ckan-ui/pull/617, I added `redisHost`, `redisPort`, and `redisPassword` values to the ckan-ui chart.

I also added `secretsPath`; it's for a coming enhancement related to the previously mentioned ticket. The plan is to add Vault support. This value will be a file system path to a JSON or YAML file (projected by Vault) containing the secrets the bridge needs to operate, to be merged with the config at runtime.