### PR TITLE
can update service account name for which a role binding can be created

### DIFF
--- a/charts/generic-api/templates/rbac.yaml
+++ b/charts/generic-api/templates/rbac.yaml
@@ -16,6 +16,6 @@ roleRef:
   name: {{ include "generic-api.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "generic-api.serviceAccountName" . }}
+    name: {{ .Values.podServiceAccountName | default (printf "%s" (include "generic-api.serviceAccountName" . )) }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/generic-api/values.yaml
+++ b/charts/generic-api/values.yaml
@@ -102,6 +102,8 @@ serviceAccount:
 
 podAnnotations: {}
 
+podServiceAccountName: ""
+
 rbac:
   create: false
   rules: []


### PR DESCRIPTION
This change will help us create a role binding to vault service account and use it in place of default one. Using vault service account for pulling secrets and as well as for carrying out app level functions. 