### PR TITLE
add pipeline parameters and ability to bind them to values passed fro…

### DIFF
--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -43,11 +43,13 @@ These are the configurable values for the tasks array, these will create new tas
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
 | `name              `              | The name for the task                | helm3-spark                               |
+| `volumes              `           | Array of volumes to be mounted       | nil                                       |
 | `steps             `              | Array of steps that make up the task | Array of size 1 object described below    |
 | `steps[0].name     `              | Name for this step                   | install-spark                             |
 | `steps[0].image     `             | The container image to use for this step | alpine/helm:3.0.2                     |
 | `steps[0].command   `             | The command to run in the container  | [/bin/ash, -c, helm repo add...]          |
-
+| `steps[0].volumeMounts   `        | Specifies mountPath for volumes      | nil                                       |
+| `steps[0].resources   `           | Can supply requests/limits memory and cpu | nil                                  |
 
 ### Pipelines
 
@@ -60,6 +62,10 @@ These are the configurable values for the pipelines array, these will create new
 | `bindingName    `                 | Binding Name for pipeline andtrigger | spark-binding                             |
 | `workspaces[].name   `            | Name of workspace to make available  | nil                                       |
 | `workspaces[].workspace `         | Workspace to make available          | nil                                       |
+| `workspaces[].persistentVolumeClaim ` | PVC name for workspace           | emptyDir                                  |
+| `workspaces[].podTemplate `       | Override default pod template, e.g. securityContext | nil                        |
+
+
 | `tasks     `                      | Array of tasks to run                | Arary of size 1 described below           |
 | `tasks[0].name   `                | Name of task in pipeline             | create-namespace                          |
 | `tasks[0].ref.name   `            | Name of task to run                  | create-namespace                          |

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -66,9 +66,13 @@ These are the configurable values for the pipelines array, these will create new
 | `tasks[0].ref.kind   `            | Type of task set to ClusterTask for non namespace task | nil                     |
 | `tasks[0].workspaces[].name   `   | Name of workspace for task           | nil                                       |
 | `tasks[0].workspaces[].workspace` | Name of workspace to use             | nil                                       |
-| `params[].name   `                | Name of task parameter               | nil                                       |
-| `params[].value  `                | Value of parameter                   | nil                                       |
-
+| `tasks[0].params[].name   `       | Name of task parameter               | nil                                       |
+| `tasks[0].params[].value   `      | Value of parameter                   | nil                                       |
+| `pipeline_params[].name   `       | Name of pipeline parameter shared across multiple tasks | nil                    |
+| `pipeline_params[].default   `    | Default value of pipeline parameter shared across multiple tasks | ''            |
+| `pipeline_params[].type   `       | Type of pipeline parameter shared across multiple tasks: string/array | string   |
+| `pipeline_params[].incomingValue` | JSONPath string used by TemplateBinding to extract value from WebHook | nil     |
+| `pipeline_params[].resourceTemplate` | Used to assign value to parameter in TemplateTrigger  | nil                   |
 
 ### Events
 
@@ -84,6 +88,7 @@ These are the configurable values for the events array, these will create new tr
 | `listeners[].triggers     `       | Array of triggers for this listener  | Arary of size 1 described below           |
 | `listeners[].triggers[].trigger`  | Name of trigger to fire              | spark-trigger-template                    |
 | `listeners[].triggers.binding `   | Name of binding to use               | spark-binding                             |
+| `listeners[].triggers.interceptors ` | Array of trigger [interceptors](https://tekton.dev/vault/triggers-main/interceptors/)     | Empty array                               |
 | `listeners[].ingress   `          | Ingress options for listener         | See below                                 |
 | `listeners[].ingress.enabled`     | Ingress enabled                      | true                                      |
 | `listeners[].ingress.name`        | Ingress name                         | spark-pipeline-ingress                    |

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -61,11 +61,8 @@ These are the configurable values for the pipelines array, these will create new
 | `triggerName       `              | Trigger Name to create for this pipeline (for events) | spark-trigger-template   |
 | `bindingName    `                 | Binding Name for pipeline andtrigger | spark-binding                             |
 | `workspaces[].name   `            | Name of workspace to make available  | nil                                       |
-| `workspaces[].workspace `         | Workspace to make available          | nil                                       |
 | `workspaces[].persistentVolumeClaim ` | PVC name for workspace           | emptyDir                                  |
 | `workspaces[].podTemplate `       | Override default pod template, e.g. securityContext | nil                        |
-
-
 | `tasks     `                      | Array of tasks to run                | Arary of size 1 described below           |
 | `tasks[0].name   `                | Name of task in pipeline             | create-namespace                          |
 | `tasks[0].ref.name   `            | Name of task to run                  | create-namespace                          |
@@ -77,8 +74,12 @@ These are the configurable values for the pipelines array, these will create new
 | `pipeline_params[].name   `       | Name of pipeline parameter shared across multiple tasks | nil                    |
 | `pipeline_params[].default   `    | Default value of pipeline parameter shared across multiple tasks | ''            |
 | `pipeline_params[].type   `       | Type of pipeline parameter shared across multiple tasks: string/array | string   |
-| `pipeline_params[].incomingValue` | JSONPath string used by TemplateBinding to extract value from WebHook | nil     |
+| `pipeline_params[].incomingValue` | JSONPath string used by TemplateBinding to extract value from WebHook | nil      |
 | `pipeline_params[].resourceTemplate` | Used to assign value to parameter in TemplateTrigger  | nil                   |
+| `serviceAccountName   `           | Array of service accounts for each task | Empty array                            |
+| `serviceAccountName[].pipelineTaskName ` | Name of task                 | nil                                        |
+| `serviceAccountName[].taskServiceAccountName `|  Name of service account| nil                                        |
+
 
 ### Events
 

--- a/charts/tekton-pipelines/examples/geocoder-pr-trigger.yaml
+++ b/charts/tekton-pipelines/examples/geocoder-pr-trigger.yaml
@@ -1,0 +1,87 @@
+nameOverride: ""
+fullnameOverride: ""
+
+tasks:
+
+
+pipelines:
+  - name: geocoder-clone-repo
+    triggerName: geocoder-trigger-pr-merged
+    bindingName: geocoder-binding-pr-merged
+    # serviceAccountName:
+    #   - pipelineTaskName: image-build
+    #     taskServiceAccountName: pipeline
+    pipeline_params:
+      - name: git-revision
+        type: string
+        description: pull request head commit id
+        default: main
+        incomingValue: $(body.pull_request.head.sha)
+        resourceTemplate: $(tt.params.git-revision)
+    workspaces:
+      - name: shared-workspace
+        volumeClaimTemplate: 2Gi
+    tasks:
+      - name: clone-repo
+        workspaces:
+          - name: output
+            workspace: shared-workspace
+        ref:
+          kind: ClusterTask
+          name: git-clone
+        params:
+          - name: url
+            value: 'https://github.com/bcgov/ols-geocoder.git'
+          # - name: git-revision
+          #   value: $(params.git-revision)
+
+events:
+  install: true
+  defaultRB: true
+  # token: token
+  listeners:
+    - name: geocoder-listener-helm
+      triggers:
+        - name: pr-open-trigger
+          trigger: geocoder-trigger-pr-open
+          binding: geocoder-binding-pr-open
+          interceptors:
+            - name: github
+              eventTypes:
+                - name: pull_request
+              secretName: github-secret
+            - name: cel
+              filter: "body.action in ['opened', 'reopened']"
+        # - name: pr-merge-trigger
+        #   trigger: geomark-trigger-pr-merged
+        #   binding: geomark-binding-pr-merged
+        #   interceptors:
+        #     - name: github
+        #       eventTypes:
+        #         - name: pull_request
+        #       secretName: github-secret
+        #     - name: cel
+        #       filter: "body.action in ['closed']"
+        #     - name: cel
+        #       filter: "body.pull_request.merged"
+        # - name: release-listener
+        #   trigger: geomark-trigger-published
+        #   binding: geomark-binding-published
+        #   interceptors:
+        #     - name: github
+        #       eventTypes:
+        #         - name: release
+        #       secretName: github-secret
+        #     - name: cel
+        #       filter: "body.action in ['published']"
+      ingress:
+        enabled: true
+        name: geocoder-ingress-helm
+        annotations:
+          kubernetes.io/ingress.class: nginx
+        path: /
+        hosts:
+          - name: el-geocoder-listener-helm-988040-tools.apps.silver.devops.gov.bc.ca
+            service: el-geocoder-listener-helm
+            port: 8080
+        tls: []

--- a/charts/tekton-pipelines/examples/geocoder-pr-trigger.yaml
+++ b/charts/tekton-pipelines/examples/geocoder-pr-trigger.yaml
@@ -1,31 +1,310 @@
 nameOverride: ""
 fullnameOverride: ""
+#serviceAccountName: pipeline
+configMaps:
+- artifactorySettingsXml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <settings
+      xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+        http://maven.apache.org/SETTINGS/1.0.0
+        http://maven.apache.org/xsd/settings-1.0.0.xsd
+      ">
+      <localRepository>/workspace/.m2/repository/</localRepository>
+      <profiles>
+        <profile>
+          <id>citz-artifactory</id>
+          <activation>
+            <activeByDefault>true</activeByDefault>
+          </activation>
+          <repositories>
+            <repository>
+              <id>delivery.bcgov</id>
+              <name>BC Government Repository</name>
+              <url>https://delivery.apps.gov.bc.ca/artifactory/repo/</url>
+              <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+                <checksumPolicy>warn</checksumPolicy>
+              </releases>
+              <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+                <checksumPolicy>warn</checksumPolicy>
+              </snapshots>
+            </repository>
+          </repositories>
+        </profile>
+      </profiles>
+    </settings>
+# PVCs:
+#   - name: pip-tkt-m2-pvc
+#     accessModes: ReadWriteMany
+#     volumeMode: Filesystem
+#     storage: 2Gi
+
 
 tasks:
+  - name: acquire-mutex
+    workspaces:
+    - name: source
+    steps:
+      - image: quay.io/openshift/origin-cli:latest
+        name: mutex
+        script: |
+          #!/usr/bin/env bash
+          cd /workspace/source/
+          echo "kind: ConfigMap" > mutex.yaml
+          echo "apiVersion: v1" >> mutex.yaml
+          echo "metadata:" >> mutex.yaml
+          echo "  name: mutex" >> mutex.yaml
+          echo "data:" >> mutex.yaml
+          echo "mutex: 'on'" >> mutex.yaml
+          echo "---Waiting for mutex---"
+          sh -c 'until $(oc create -f mutex.yaml &>/dev/null); do printf '.'; sleep 5; done;'
+          echo "---Mutex acquired---"
+  - name: release-mutex
+    workspaces:
+    - name: source
+    steps:
+      - image: quay.io/openshift/origin-cli:latest
+        name: mutex
+        script: |
+          #!/usr/bin/env sh
+          oc delete configmap mutex
+          echo "---Mutex released---"
+  - name: tests-helm
+    params:
+      - name: api_url
+        type: string
+    workspaces:
+    - name: source
+    - name: pr
+    steps:
+      - image: registry.fedoraproject.org/f33/python3:latest
+        name: pytest
+        env:
+        - name: API_URL
+          value: $(params.api_url)
+        script: |
+          #!/usr/bin/env sh
+          cd /workspace/pr/
+          mkdir -p comments
+          cd /workspace/source/geocoder-testing
+          python -m pip install pytest
+          python -m pip install requests
+          NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          python -m pytest --maxfail=10 --api_url=$API_URL > /workspace/pr/comments/$NOW
+  - name: cli-build-helm
+    params:
+      - name: git-revision
+        type: string
+      - name: image-tag
+        type: string
+      - name: route-url
+        type: string
+      - name: ns
+        type: string
+    volumes:
+      - name: m2-vol
+        persistentVolumeClaim: pip-tkt-m2-pvc
+    workspaces:
+    - name: source
+    steps:
+      - image: quay.io/openshift/origin-cli:latest
+        name: image-build
+        volumeMounts:
+          - name: m2-vol
+            mountPath: /workspace/m2-content
+        env:
+        - name: GIT_REVISION
+          value: $(params.git-revision)
+        - name: IMG_TAG
+          value: $(params.image-tag)
+        - name: ROUTE_URL
+          value: $(params.route-url)
+        - name: NAME_SPACE
+          value: $(params.ns)
+        script: |
+          #!/usr/bin/env sh
+          echo "---Moving .war to staging area---"
+          cd /workspace/source/
+          rm -rf war1 || true
+          rm -rf war2 || true
+          mkdir war1
+          mkdir war2
+          git_rev=$(echo "$GIT_REVISION")
+          cp "/workspace/m2-content/ca/bc/gov/ols/ols-geocoder-admin/${git_rev}/ols-geocoder-admin-${git_rev}.war" /workspace/source/war1/ols-admin.war
+          cp "/workspace/m2-content/ca/bc/gov/ols/ols-geocoder-web/${git_rev}/ols-geocoder-web-${git_rev}.war" /workspace/source/war2/geocoder.war
 
+          echo "--Commencing the build--"
+          oc start-build geocoder-sidecar --from-dir=/workspace/source/war2 --wait
+          oc tag geocoder-sidecar:latest geocoder-sidecar:$IMG_TAG
+
+          oc start-build ols-admin-sidecar --from-dir=/workspace/source/war1 --wait
+          oc tag ols-admin-sidecar:latest ols-admin-sidecar:$IMG_TAG
+
+          sh -c 'until $(curl --output /dev/null --silent --head --fail $ROUTE_URL); do printf '.'; sleep 5; done;'
+          echo "---Geocoder is up in test namespace---"
+  - name: maven-helm
+    params:
+    - name: git-revision
+      type: string
+    volumes:
+    - name: m2-vol
+      persistentVolumeClaim: pip-tkt-m2-pvc
+    - name: conf-vol
+      configMap: maven-settings
+    workspaces:
+      - name: source
+      - name: pr
+    steps:
+      - name: build
+        image: maven:3.8.1-jdk-11-slim
+        script: |
+          #!/usr/bin/env bash
+          /usr/bin/mvn versions:set -s /workspace/.m2/settings.xml -DnewVersion=$GIT_REVISION -DgroupId='*' -DgenerateBackupPoms=false
+          NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          /usr/bin/mvn install -Dmaven.test.skip=true -s /workspace/.m2/settings.xml > /workspace/pr/comments/$NOW
+          if [[ "$?" -eq 0 ]] ; then
+            rm /workspace/pr/comments/$NOW;
+          fi
+          echo "---Maven build complete---"
+        env:
+        - name: GIT_REVISION
+          value: $(params.git-revision)
+        - name: MAVEN_OPTS
+          value: "-server -Xms256m -Xmx512m -XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
+        volumeMounts:
+        - name: conf-vol
+          mountPath: /workspace/.m2
+        - name: m2-vol
+          mountPath: /workspace/.m2/repository
+        workingDir: /workspace/source
+        resources:
+          requests:
+            memory: 500Mi
+            cpu: 250m
+          limits:
+            memory: 3Gi
+            cpu: "2"
 
 pipelines:
-  - name: geocoder-clone-repo
-    triggerName: geocoder-trigger-pr-open
-    bindingName: geocoder-binding-pr-open
+  - name: geocoder-merge
+    triggerName: geocoder-trigger-pr-merged
+    bindingName: geocoder-binding-pr-merged
     serviceAccountName:
-      - pipelineTaskName: clone-repo
+      - pipelineTaskName: image-build
         taskServiceAccountName: pipeline
     pipeline_params:
-      - name: git-url
-        type: string
-        description: git repo url
-        incomingValue: $(body.repository.ssh_url)
-        resourceTemplate: $(tt.params.git-url)
       - name: git-revision
         type: string
         description: pull request head commit id
         default: main
         incomingValue: $(body.pull_request.head.sha)
         resourceTemplate: $(tt.params.git-revision)
+      - name: ns
+        description: namespace used for dev deployment
+        type: string
+        default: f8d638-dev
+      - name: image-tag
+        description: image deployment trigger tag
+        type: string
+        default: dev
+      - name: route-url
+        type: string
+        description: api url subject to testing
+        default: https://geomark-tomcat-f8d638-dev.apps.silver.devops.gov.bc.ca/pub/geomark/geomarks/
     workspaces:
       - name: shared-workspace
-        volumeClaimTemplate: 1Gi
+        volumeClaimTemplate: 2Gi
+    tasks:
+      - name: get-mutex
+        ref:
+          name: acquire-mutex
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+      - name: image-build
+        ref:
+          name: cli-build-helm
+        runAfter:
+          - get-mutex
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+        params:
+          - name: git-revision
+            value: $(params.git-revision)
+          - name: image-tag
+            value: $(params.image-tag)
+          - name: route-url
+            value: $(params.route-url)
+          - name: ns
+            value: 988040-dev
+    finally:
+      - name: free-mutex
+        ref:
+          name: release-mutex
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+  - name: geocoder-clone-repo
+    triggerName: geocoder-trigger-pr-open
+    bindingName: geocoder-binding-pr-open
+    serviceAccountName:
+      - pipelineTaskName: clone-repo
+        taskServiceAccountName: git-bot
+      - pipelineTaskName: maven-build
+        taskServiceAccountName: pipeline
+      - pipelineTaskName: pull-tests
+        taskServiceAccountName: git-bot
+      - pipelineTaskName: run-tests
+        taskServiceAccountName: pipeline
+
+    pipeline_params:
+      - name: git-url
+        type: string
+        description: git repo url
+        default: https://github.com/bcgov/ols-geocoder.git
+      - name: git-revision
+        type: string
+        description: pull request head commit id
+        default: main
+        incomingValue: $(body.pull_request.head.sha)
+        resourceTemplate: $(tt.params.git-revision)
+      - name: pr-url
+        description: pull request url
+        type: string
+        incomingValue: $(body.pull_request.html_url)
+        resourceTemplate: $(tt.params.pr-url)
+      - name: route-url
+        type: string
+        description: test query to check that the app is alive
+        default: https://geocoder-test.apps.silver.devops.gov.bc.ca/addresses.json?addressString=525+Superior+St%09+Victoria%09+BC
+      - name: git-auth-token
+        description: machine account auth token used for pushing content
+        type: string
+        default: github-auth-token
+      - name: ns
+        description: namespace used for test deployment
+        type: string
+        default: 988040-test
+      - name: image-tag
+        description: image deployment trigger tag
+        type: string
+        default: test
+    workspaces:
+      - name: shared-workspace
+        volumeClaimTemplate: 2Gi
+      - name: input
+      - name: pr-content
+        volumeClaimTemplate: 50Mi
+    podTemplate:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
     tasks:
       - name: clone-repo
         workspaces:
@@ -36,14 +315,119 @@ pipelines:
           name: git-clone
         params:
           - name: url
-            value: https://github.com/bcgov/ols-geocoder.git
-            # value: $(params.git-url)
+            value: $(params.git-url)
           - name: revision
             value: $(params.git-revision)
-
+      - name: pull-pr-meta
+        ref:
+          name: pull-request
+          kind: ClusterTask
+        workspaces:
+        - name: pr
+          workspace: pr-content
+        params:
+        - name: url
+          value: $(params.pr-url)
+        - name: secret-key-ref
+          value: github-auth-token
+        - name: mode
+          value: download
+        - name: provider
+          value: github
+        runAfter:
+        - clone-repo
+      - name: maven-build
+        ref:
+          name: maven-helm
+        params:
+        - name: git-revision
+          value: $(params.git-revision)
+        runAfter:
+          - pull-pr-meta
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: pr
+          workspace: pr-content
+      - name: get-mutex
+        ref:
+          name: acquire-mutex
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+        runAfter:
+        - maven-build
+      - name: image-build
+        ref:
+          name: cli-build-helm
+        runAfter:
+          - get-mutex
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+        params:
+          - name: git-revision
+            value: $(params.git-revision)
+          - name: image-tag
+            value: $(params.image-tag)
+          - name: route-url
+            value: $(params.route-url)
+          - name: ns
+            value: $(params.ns)
+      - name: pull-tests
+        ref:
+          name: git-cli
+          kind: ClusterTask
+        runAfter:
+          - image-build
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: input
+          workspace: input
+        params:
+        - name: GIT_SCRIPT
+          value: |
+            git reset --hard && git clean -f && git fetch origin && git checkout -b tools origin/tools-tekton
+      - name: run-tests
+        ref:
+          name: tests-helm
+        runAfter:
+          - pull-tests
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: pr
+          workspace: pr-content
+        params:
+        - name: api_url
+          value: $(params.route-url)
+    finally:
+      - name: free-mutex
+        ref:
+          name: release-mutex
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+      - name: notify-test-results
+        ref:
+          name: pull-request
+          kind: ClusterTask
+        workspaces:
+        - name: pr
+          workspace: pr-content
+        params:
+        - name: url
+          value: $(params.pr-url)
+        - name: secret-key-ref
+          value: $(params.git-auth-token)
+        - name: mode
+          value: upload
+        - name: provider
+          value: github
 events:
   install: true
-  defaultRB: true
+  defaultRB: false
   listeners:
     - name: geocoder-listener-helm
       triggers:
@@ -54,8 +438,21 @@ events:
             - name: github
               eventTypes:
                 - name: pull_request
+              secretName: github-secret
             - name: cel
               filter: "body.action in ['opened', 'reopened']"
+        - name: pr-merge-trigger
+          trigger: geocoder-trigger-pr-merged
+          binding: geocoder-binding-pr-merged
+          interceptors:
+            - name: github
+              eventTypes:
+                - name: pull_request
+              secretName: github-secret
+            - name: cel
+              filter: "body.action in ['closed']"
+            - name: cel
+              filter: "body.pull_request.merged"
       ingress:
         enabled: true
         name: geocoder-ingress-helm

--- a/charts/tekton-pipelines/examples/geocoder-pr-trigger.yaml
+++ b/charts/tekton-pipelines/examples/geocoder-pr-trigger.yaml
@@ -6,12 +6,17 @@ tasks:
 
 pipelines:
   - name: geocoder-clone-repo
-    triggerName: geocoder-trigger-pr-merged
-    bindingName: geocoder-binding-pr-merged
-    # serviceAccountName:
-    #   - pipelineTaskName: image-build
-    #     taskServiceAccountName: pipeline
+    triggerName: geocoder-trigger-pr-open
+    bindingName: geocoder-binding-pr-open
+    serviceAccountName:
+      - pipelineTaskName: clone-repo
+        taskServiceAccountName: pipeline
     pipeline_params:
+      - name: git-url
+        type: string
+        description: git repo url
+        incomingValue: $(body.repository.ssh_url)
+        resourceTemplate: $(tt.params.git-url)
       - name: git-revision
         type: string
         description: pull request head commit id
@@ -20,7 +25,7 @@ pipelines:
         resourceTemplate: $(tt.params.git-revision)
     workspaces:
       - name: shared-workspace
-        volumeClaimTemplate: 2Gi
+        volumeClaimTemplate: 1Gi
     tasks:
       - name: clone-repo
         workspaces:
@@ -31,14 +36,14 @@ pipelines:
           name: git-clone
         params:
           - name: url
-            value: 'https://github.com/bcgov/ols-geocoder.git'
-          # - name: git-revision
-          #   value: $(params.git-revision)
+            value: https://github.com/bcgov/ols-geocoder.git
+            # value: $(params.git-url)
+          - name: revision
+            value: $(params.git-revision)
 
 events:
   install: true
-  defaultRB: true
-  # token: token
+  defaultRB: false
   listeners:
     - name: geocoder-listener-helm
       triggers:
@@ -49,39 +54,12 @@ events:
             - name: github
               eventTypes:
                 - name: pull_request
-              secretName: github-secret
             - name: cel
               filter: "body.action in ['opened', 'reopened']"
-        # - name: pr-merge-trigger
-        #   trigger: geomark-trigger-pr-merged
-        #   binding: geomark-binding-pr-merged
-        #   interceptors:
-        #     - name: github
-        #       eventTypes:
-        #         - name: pull_request
-        #       secretName: github-secret
-        #     - name: cel
-        #       filter: "body.action in ['closed']"
-        #     - name: cel
-        #       filter: "body.pull_request.merged"
-        # - name: release-listener
-        #   trigger: geomark-trigger-published
-        #   binding: geomark-binding-published
-        #   interceptors:
-        #     - name: github
-        #       eventTypes:
-        #         - name: release
-        #       secretName: github-secret
-        #     - name: cel
-        #       filter: "body.action in ['published']"
       ingress:
         enabled: true
         name: geocoder-ingress-helm
         annotations:
-          kubernetes.io/ingress.class: nginx
-        path: /
-        hosts:
-          - name: el-geocoder-listener-helm-988040-tools.apps.silver.devops.gov.bc.ca
-            service: el-geocoder-listener-helm
-            port: 8080
-        tls: []
+          openshift.io/host.generated: 'true'
+        host: el-geocoder-listener-helm-988040-tools.apps.silver.devops.gov.bc.ca
+        service: el-geocoder-listener-helm

--- a/charts/tekton-pipelines/examples/geocoder-pr-trigger.yaml
+++ b/charts/tekton-pipelines/examples/geocoder-pr-trigger.yaml
@@ -43,7 +43,7 @@ pipelines:
 
 events:
   install: true
-  defaultRB: false
+  defaultRB: true
   listeners:
     - name: geocoder-listener-helm
       triggers:

--- a/charts/tekton-pipelines/examples/open-pr-trigger.yaml
+++ b/charts/tekton-pipelines/examples/open-pr-trigger.yaml
@@ -1,0 +1,71 @@
+serviceAccountName: git-bot
+
+nameOverride: ""
+fullnameOverride: ""
+
+pipelines:
+  - name: geomark-clone-helm
+    triggerName: geomark-trigger-helm
+    bindingName: geomark-binding-helm
+    pipeline_params:
+      - name: git-url
+        type: string
+        description: git repo url
+        incomingValue: $(body.repository.ssh_url)
+        resourceTemplate: $(tt.params.git-url)
+      - name: pr-url
+        description: pull request url
+        type: string
+        incomingValue: $(body.pull_request.html_url)
+        resourceTemplate: $(tt.params.pr-url)
+      - name: git-revision
+        type: string
+        description: pull request head commit id
+        default: main
+        incomingValue: $(body.pull_request.head.sha)
+        resourceTemplate: $(tt.params.git-revision)
+    workspaces:
+      - name: output
+        workspace: shared-workspace
+    tasks:
+      - name: clone-repo
+        workspaces:
+          - name: output
+            workspace: shared-workspace
+        ref:
+          kind: ClusterTask
+          name: git-clone
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.git-revision)
+
+events:
+  install: true
+  defaultRB: true
+  token: token
+  listeners:
+    - name: geomark-listener-helm
+      triggers:
+        - name: pr-open-trigger
+          trigger: geomark-trigger-helm
+          binding: geomark-binding-helm
+          interceptors:
+            - name: github
+              eventTypes:
+                - name: pull_request
+              secretName: github-secret
+            - name: cel
+              filter: "body.action in ['opened', 'reopened']"
+      ingress:
+        enabled: true
+        name: geomark-ingress-helm
+        annotations:
+          kubernetes.io/ingress.class: nginx
+        path: /
+        hosts:
+          - name: el-geomark-listener-helm-f8d638-tools.apps.silver.devops.gov.bc.ca
+            service: el-geomark-listener-helm
+            port: 8080
+        tls: []

--- a/charts/tekton-pipelines/examples/open-pr-trigger.yaml
+++ b/charts/tekton-pipelines/examples/open-pr-trigger.yaml
@@ -2,6 +2,30 @@ nameOverride: ""
 fullnameOverride: ""
 
 tasks:
+  - name: tests-helm
+    params:
+      - name: api_url
+        type: string
+    workspaces:
+    - name: source
+    - name: pr
+    steps:
+      - image: registry.fedoraproject.org/f33/python3:latest
+        name: pytest
+        env:
+        - name: API_URL
+          value: $(params.api_url)
+        script: |
+          #!/usr/bin/env sh
+          cd /workspace/pr/
+          mkdir -p comments
+          cd /workspace/source/geomark-testing
+          python -m pip install pytest
+          python -m pip install shapely
+          python -m pip install fiona
+          python -m pip install requests
+          NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          python -m pytest -sv --api_url=$API_URL > /workspace/pr/comments/$NOW
   - name: cli-build-helm
     params:
       - name: git-tag
@@ -86,7 +110,7 @@ tasks:
 
 
 pipelines:
-  - name: geomark-clone-build-helm
+  - name: geomark-pr-helm
     triggerName: geomark-trigger-helm
     bindingName: geomark-binding-helm
     serviceAccountName:
@@ -94,7 +118,9 @@ pipelines:
         taskServiceAccountName: git-bot
       - pipelineTaskName: maven-build
         taskServiceAccountName: pipeline
-      - pipelineTaskName: image-build
+      - pipelineTaskName: pull-tests
+        taskServiceAccountName: git-bot
+      - pipelineTaskName: run-tests
         taskServiceAccountName: pipeline
     pipeline_params:
       - name: git-url
@@ -117,6 +143,8 @@ pipelines:
       - name: shared-workspace
         persistentVolumeClaim: pip-tkt-repo-pvc
       - name: input
+      - name: pr-content
+        persistentVolumeClaim: pr-pvc
     podTemplate:
       securityContext:
         runAsNonRoot: true
@@ -161,7 +189,69 @@ pipelines:
             value: https://geomark-tomcat-f8d638-test.apps.silver.devops.gov.bc.ca/pub/geomark/geomarks/
           - name: ns
             value: f8d638-test
-
+      - name: pull-tests
+        ref:
+          name: git-cli
+          kind: ClusterTask
+        runAfter:
+          - image-build
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: input
+          workspace: input
+        params:
+        - name: GIT_SCRIPT
+          value: |
+              git reset --hard && git clean -f && git fetch && git checkout tools
+      - name: pull-pr-meta
+        ref:
+          name: pull-request
+          kind: ClusterTask
+        workspaces:
+        - name: pr
+          workspace: pr-content
+        params:
+        - name: url
+          value: $(params.pr-url)
+        - name: secret-key-ref
+          value: github-auth-token
+        - name: mode
+          value: download
+        - name: provider
+          value: github
+        runAfter:
+        - pull-tests
+      - name: run-tests
+        ref:
+          name: tests-helm
+        runAfter:
+          - pull-pr-meta
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: pr
+          workspace: pr-content
+        params:
+        - name: api_url
+          value: "https://geomark-tomcat-f8d638-test.apps.silver.devops.gov.bc.ca/pub/geomark/api/geomarks/"
+    finally:
+      - name: notify-test-results
+        ref:
+          name: pull-request
+          kind: ClusterTask
+        workspaces:
+        - name: pr
+          workspace: pr-content
+        params:
+        - name: url
+          value: $(params.pr-url)
+        - name: secret-key-ref
+          value: github-auth-token
+        - name: mode
+          value: upload
+        - name: provider
+          value: github
 events:
   install: true
   defaultRB: true

--- a/charts/tekton-pipelines/examples/open-pr-trigger.yaml
+++ b/charts/tekton-pipelines/examples/open-pr-trigger.yaml
@@ -2,6 +2,34 @@ nameOverride: ""
 fullnameOverride: ""
 
 tasks:
+  - name: acquire-mutex
+    workspaces:
+    - name: source
+    steps:
+      - image: quay.io/openshift/origin-cli:latest
+        name: mutex
+        script: |
+          #!/usr/bin/env bash
+          cd /workspace/source/
+          echo "kind: ConfigMap" > mutex.yaml
+          echo "apiVersion: v1" >> mutex.yaml
+          echo "metadata:" >> mutex.yaml
+          echo "  name: mutex" >> mutex.yaml
+          echo "data:" >> mutex.yaml
+          echo "mutex: 'on'" >> mutex.yaml
+          echo "---Waiting for mutex---"
+          sh -c 'until $(oc create -f mutex.yaml &>/dev/null); do printf '.'; sleep 5; done;'
+          echo "---Mutex acquired---"
+  - name: release-mutex
+    workspaces:
+    - name: source
+    steps:
+      - image: quay.io/openshift/origin-cli:latest
+        name: mutex
+        script: |
+          #!/usr/bin/env sh
+          oc delete configmap mutex
+          echo "---Mutex released---"
   - name: tests-helm
     params:
       - name: api_url
@@ -28,7 +56,7 @@ tasks:
           python -m pytest -sv --api_url=$API_URL > /workspace/pr/comments/$NOW
   - name: cli-build-helm
     params:
-      - name: git-tag
+      - name: git-revision
         type: string
       - name: image-tag
         type: string
@@ -48,8 +76,8 @@ tasks:
           - name: m2-vol
             mountPath: /workspace/m2-content
         env:
-        - name: GIT_TAG
-          value: $(params.git-tag)
+        - name: GIT_REVISION
+          value: $(params.git-revision)
         - name: IMG_TAG
           value: $(params.image-tag)
         - name: ROUTE_URL
@@ -62,8 +90,8 @@ tasks:
           cd /workspace/source/
           rm -rf war || true
           mkdir war
-          git_tag=$(echo "$GIT_TAG" | sed "s/.*\///")
-          cp "/workspace/m2-content/ca/bc/gov/geomark/geomark-war/${git_tag}/geomark-war-${git_tag}.war" /workspace/source/war/pub#geomark.war
+          git_rev=$(echo "$GIT_REVISION")
+          cp "/workspace/m2-content/ca/bc/gov/geomark/geomark-war/${git_rev}/geomark-war-${git_rev}.war" /workspace/source/war/pub#geomark.war
           cd war
           echo "--Commencing the build--"
           oc start-build geomark-sidecar --from-dir=/workspace/source/war --wait
@@ -75,6 +103,9 @@ tasks:
           sh -c 'until $(curl --output /dev/null --silent --head --fail $ROUTE_URL); do printf '.'; sleep 5; done;'
           echo "---Geomark is up in test namespace---"
   - name: maven-helm
+    params:
+    - name: git-revision
+      type: string
     volumes:
     - name: m2-vol
       persistentVolumeClaim: pip-tkt-m2-pvc
@@ -88,6 +119,8 @@ tasks:
         image: maven:3.8.2-jdk-11-slim
         script: |
           #!/usr/bin/env bash
+          /usr/bin/mvn versions:set -s /workspace/.m2/settings.xml -DnewVersion=$GIT_REVISION -DgroupId='*' -DgenerateBackupPoms=false
+          sed -i "s/__VERSION__mvn/$GIT_REVISION/g" src/docs/*.html
           NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           /usr/bin/mvn install -q -s /workspace/.m2/settings.xml > /workspace/pr/comments/$NOW
           if [[ "$?" -eq 0 ]] ; then
@@ -95,6 +128,8 @@ tasks:
           fi
           echo "---Maven build complete---"
         env:
+        - name: GIT_REVISION
+          value: $(params.git-revision)
         - name: MAVEN_OPTS
           value: "-server -Xms256m -Xmx512m -XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
         volumeMounts:
@@ -145,7 +180,7 @@ pipelines:
       - name: route-url
         type: string
         description: api url subject to testing
-        default: https://geomark-tomcat-f8d638-test.apps.silver.devops.gov.bc.ca/pub/geomark/api/geomarks/
+        default: https://geomark-tomcat-f8d638-test.apps.silver.devops.gov.bc.ca/pub/geomark/geomarks/
       - name: git-auth-token
         description: machine account auth token used for pushing content
         type: string
@@ -206,6 +241,9 @@ pipelines:
       - name: maven-build
         ref:
           name: maven-helm
+        params:
+        - name: git-revision
+          value: $(params.git-revision)
         runAfter:
           - pull-pr-meta
         workspaces:
@@ -213,17 +251,25 @@ pipelines:
           workspace: shared-workspace
         - name: pr
           workspace: pr-content
+      - name: get-mutex
+        ref:
+          name: acquire-mutex
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+        runAfter:
+        - maven-build
       - name: image-build
         ref:
           name: cli-build-helm
         runAfter:
-          - maven-build
+          - get-mutex
         workspaces:
         - name: source
           workspace: shared-workspace
         params:
-          - name: git-tag
-            value: $(params.git-tag)
+          - name: git-revision
+            value: $(params.git-revision)
             # value: $(params.git-revision)
           - name: image-tag
             value: $(params.image-tag)
@@ -260,6 +306,12 @@ pipelines:
         - name: api_url
           value: $(params.route-url)
     finally:
+      - name: free-mutex
+        ref:
+          name: release-mutex
+        workspaces:
+        - name: source
+          workspace: shared-workspace
       - name: notify-test-results
         ref:
           name: pull-request

--- a/charts/tekton-pipelines/examples/open-pr-trigger.yaml
+++ b/charts/tekton-pipelines/examples/open-pr-trigger.yaml
@@ -148,9 +148,68 @@ tasks:
 
 
 pipelines:
-  - name: geomark-pr-helm
-    triggerName: geomark-trigger-helm
-    bindingName: geomark-binding-helm
+  - name: geomark-merge
+    triggerName: geomark-trigger-pr-merged
+    bindingName: geomark-binding-pr-merged
+    serviceAccountName:
+      - pipelineTaskName: image-build
+        taskServiceAccountName: pipeline
+    pipeline_params:
+      - name: git-revision
+        type: string
+        description: pull request head commit id
+        default: main
+        incomingValue: $(body.pull_request.head.sha)
+        resourceTemplate: $(tt.params.git-revision)
+      - name: ns
+        description: namespace used for dev deployment
+        type: string
+        default: f8d638-dev
+      - name: image-tag
+        description: image deployment trigger tag
+        type: string
+        default: dev
+      - name: route-url
+        type: string
+        description: api url subject to testing
+        default: https://geomark-tomcat-f8d638-dev.apps.silver.devops.gov.bc.ca/pub/geomark/geomarks/
+    workspaces:
+      - name: shared-workspace
+        volumeClaimTemplate: 2Gi
+    tasks:
+      - name: get-mutex
+        ref:
+          name: acquire-mutex
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+      - name: image-build
+        ref:
+          name: cli-build-helm
+        runAfter:
+          - get-mutex
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+        params:
+          - name: git-revision
+            value: $(params.git-revision)
+          - name: image-tag
+            value: $(params.image-tag)
+          - name: route-url
+            value: $(params.route-url)
+          - name: ns
+            value: $(params.ns)
+    finally:
+      - name: free-mutex
+        ref:
+          name: release-mutex
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+  - name: geomark-test
+    triggerName: geomark-trigger-pr-open
+    bindingName: geomark-binding-pr-open
     serviceAccountName:
       - pipelineTaskName: clone-repo
         taskServiceAccountName: git-bot
@@ -185,10 +244,6 @@ pipelines:
         description: machine account auth token used for pushing content
         type: string
         default: github-auth-token
-      - name: git-tag
-        description: default tag that is build in main
-        type: string
-        default: 6.0.x-SNAPSHOT
       - name: ns
         description: namespace used for test deployment
         type: string
@@ -270,7 +325,6 @@ pipelines:
         params:
           - name: git-revision
             value: $(params.git-revision)
-            # value: $(params.git-revision)
           - name: image-tag
             value: $(params.image-tag)
           - name: route-url
@@ -333,11 +387,11 @@ events:
   defaultRB: true
   token: token
   listeners:
-    - name: geomark-listener-helm
+    - name: geomark-listener
       triggers:
         - name: pr-open-trigger
-          trigger: geomark-trigger-helm
-          binding: geomark-binding-helm
+          trigger: geomark-trigger-pr-open
+          binding: geomark-binding-pr-open
           interceptors:
             - name: github
               eventTypes:
@@ -345,14 +399,32 @@ events:
               secretName: github-secret
             - name: cel
               filter: "body.action in ['opened', 'reopened']"
+        - name: pr-merge-trigger
+          trigger: geomark-trigger-pr-merged
+          binding: geomark-binding-pr-merged
+          interceptors:
+            - name: github
+              eventTypes:
+                - name: pull_request
+              secretName: github-secret
+            - name: cel
+              filter: "body.action in ['closed']"
+            - name: cel
+              filter: "body.pull_request.merged"
+        - name: release-listener
+          trigger: geomark-trigger-published
+          binding: geomark-binding-published
+          interceptors:
+            - name: github
+              eventTypes:
+                - name: release
+              secretName: github-secret
+            - name: cel
+              filter: "body.action in ['published']"
       ingress:
         enabled: true
-        name: geomark-ingress-helm
+        name: geomark-route
         annotations:
-          kubernetes.io/ingress.class: nginx
-        path: /
-        hosts:
-          - name: el-geomark-listener-helm-f8d638-tools.apps.silver.devops.gov.bc.ca
-            service: el-geomark-listener-helm
-            port: 8080
-        tls: []
+          openshift.io/host.generated: 'true'
+        host: el-geomark-listener-f8d638-tools.apps.silver.devops.gov.bc.ca
+        service: el-geomark-listener

--- a/charts/tekton-pipelines/examples/open-pr-trigger.yaml
+++ b/charts/tekton-pipelines/examples/open-pr-trigger.yaml
@@ -3,6 +3,42 @@ serviceAccountName: git-bot
 nameOverride: ""
 fullnameOverride: ""
 
+tasks:
+  - name: maven-helm
+    volumes:
+    - name: m2-vol
+      persistentVolumeClaim: pip-tkt-m2-pvc
+    - name: conf-vol
+      configMap: maven-config
+    workspaces:
+      - name: source
+    steps:
+      - name: build
+        image: maven:3.8.2-jdk-11-slim
+        command:
+          - /bin/bash
+          - "-s"
+          - "/workspace/mvn-config/settings.xml"
+          - "/usr/bin/mvn"
+          - "install"
+        env:
+        - name: MAVEN_OPTS
+          value: "-server -Xms256m -Xmx512m -XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
+        volumeMounts:
+        - name: conf-vol
+          mountPath: /workspace/mvn-config
+        - name: m2-vol
+          mountPath: /workspace/.m2/repository
+        workingDir: /workspace/source
+        resources:
+          requests:
+            memory: 500Mi
+            cpu: 250m
+          limits:
+            memory: 3Gi
+            cpu: "2"
+
+
 pipelines:
   - name: geomark-clone-helm
     triggerName: geomark-trigger-helm
@@ -27,6 +63,11 @@ pipelines:
     workspaces:
       - name: output
         workspace: shared-workspace
+        persistentVolumeClaim: pip-tkt-repo-pvc
+    podTemplate:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
     tasks:
       - name: clone-repo
         workspaces:
@@ -40,6 +81,14 @@ pipelines:
             value: $(params.git-url)
           - name: revision
             value: $(params.git-revision)
+      - name: maven-build
+        ref:
+          name: maven-helm
+        runAfter:
+          - clone-repo
+        workspaces:
+        - name: source
+          workspace: shared-workspace
 
 events:
   install: true

--- a/charts/tekton-pipelines/examples/open-pr-trigger.yaml
+++ b/charts/tekton-pipelines/examples/open-pr-trigger.yaml
@@ -58,7 +58,7 @@ tasks:
           value: $(params.ns)
         script: |
           #!/usr/bin/env sh
-          echo "---Moving .war to staging area--"
+          echo "---Moving .war to staging area---"
           cd /workspace/source/
           rm -rf war || true
           mkdir war
@@ -82,15 +82,18 @@ tasks:
       configMap: maven-settings
     workspaces:
       - name: source
+      - name: pr
     steps:
       - name: build
         image: maven:3.8.2-jdk-11-slim
-        command:
-          - /bin/bash
-          - "/usr/bin/mvn"
-          - "install"
-          - "-s"
-          - "/workspace/.m2/settings.xml"
+        script: |
+          #!/usr/bin/env bash
+          NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          /usr/bin/mvn install -q -s /workspace/.m2/settings.xml > /workspace/pr/comments/$NOW
+          if [[ "$?" -eq 0 ]] ; then
+            rm /workspace/pr/comments/$NOW;
+          fi
+          echo "---Maven build complete---"
         env:
         - name: MAVEN_OPTS
           value: "-server -Xms256m -Xmx512m -XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
@@ -141,10 +144,10 @@ pipelines:
         resourceTemplate: $(tt.params.git-revision)
     workspaces:
       - name: shared-workspace
-        persistentVolumeClaim: pip-tkt-repo-pvc
+        volumeClaimTemplate: 2Gi
       - name: input
       - name: pr-content
-        persistentVolumeClaim: pr-pvc
+        volumeClaimTemplate: 50Mi
     podTemplate:
       securityContext:
         runAsNonRoot: true
@@ -162,15 +165,34 @@ pipelines:
             value: $(params.git-url)
           - name: revision
             value: $(params.git-revision)
+      - name: pull-pr-meta
+        ref:
+          name: pull-request
+          kind: ClusterTask
+        workspaces:
+        - name: pr
+          workspace: pr-content
+        params:
+        - name: url
+          value: $(params.pr-url)
+        - name: secret-key-ref
+          value: github-auth-token
+        - name: mode
+          value: download
+        - name: provider
+          value: github
+        runAfter:
+        - clone-repo
       - name: maven-build
         ref:
           name: maven-helm
         runAfter:
-          - clone-repo
+          - pull-pr-meta
         workspaces:
         - name: source
           workspace: shared-workspace
-
+        - name: pr
+          workspace: pr-content
       - name: image-build
         ref:
           name: cli-build-helm
@@ -203,30 +225,12 @@ pipelines:
         params:
         - name: GIT_SCRIPT
           value: |
-              git reset --hard && git clean -f && git fetch && git checkout tools
-      - name: pull-pr-meta
-        ref:
-          name: pull-request
-          kind: ClusterTask
-        workspaces:
-        - name: pr
-          workspace: pr-content
-        params:
-        - name: url
-          value: $(params.pr-url)
-        - name: secret-key-ref
-          value: github-auth-token
-        - name: mode
-          value: download
-        - name: provider
-          value: github
-        runAfter:
-        - pull-tests
+            git reset --hard && git clean -f && git fetch origin && git checkout -b tools origin/tools
       - name: run-tests
         ref:
           name: tests-helm
         runAfter:
-          - pull-pr-meta
+          - pull-tests
         workspaces:
         - name: source
           workspace: shared-workspace

--- a/charts/tekton-pipelines/examples/open-pr-trigger.yaml
+++ b/charts/tekton-pipelines/examples/open-pr-trigger.yaml
@@ -1,15 +1,61 @@
-serviceAccountName: git-bot
-
 nameOverride: ""
 fullnameOverride: ""
 
 tasks:
+  - name: cli-build-helm
+    params:
+      - name: git-tag
+        type: string
+      - name: image-tag
+        type: string
+      - name: route-url
+        type: string
+      - name: ns
+        type: string
+    volumes:
+      - name: m2-vol
+        persistentVolumeClaim: pip-tkt-m2-pvc
+    workspaces:
+    - name: source
+    steps:
+      - image: quay.io/openshift/origin-cli:latest
+        name: image-build
+        volumeMounts:
+          - name: m2-vol
+            mountPath: /workspace/m2-content
+        env:
+        - name: GIT_TAG
+          value: $(params.git-tag)
+        - name: IMG_TAG
+          value: $(params.image-tag)
+        - name: ROUTE_URL
+          value: $(params.route-url)
+        - name: NAME_SPACE
+          value: $(params.ns)
+        script: |
+          #!/usr/bin/env sh
+          echo "---Moving .war to staging area--"
+          cd /workspace/source/
+          rm -rf war || true
+          mkdir war
+          git_tag=$(echo "$GIT_TAG" | sed "s/.*\///")
+          cp "/workspace/m2-content/ca/bc/gov/geomark/geomark-war/${git_tag}/geomark-war-${git_tag}.war" /workspace/source/war/pub#geomark.war
+          cd war
+          echo "--Commencing the build--"
+          oc start-build geomark-sidecar --from-dir=/workspace/source/war --wait
+          oc tag geomark-sidecar:latest geomark-sidecar:$IMG_TAG
+          oc start-build tomcat --wait
+          oc tag tomcat:latest tomcat:$IMG_TAG
+          oc -n $NAME_SPACE scale deployment/geomark-tomcat --replicas=0
+          oc -n $NAME_SPACE scale deployment/geomark-tomcat --replicas=1
+          sh -c 'until $(curl --output /dev/null --silent --head --fail $ROUTE_URL); do printf '.'; sleep 5; done;'
+          echo "---Geomark is up in test namespace---"
   - name: maven-helm
     volumes:
     - name: m2-vol
       persistentVolumeClaim: pip-tkt-m2-pvc
     - name: conf-vol
-      configMap: maven-config
+      configMap: maven-settings
     workspaces:
       - name: source
     steps:
@@ -17,16 +63,16 @@ tasks:
         image: maven:3.8.2-jdk-11-slim
         command:
           - /bin/bash
-          - "-s"
-          - "/workspace/mvn-config/settings.xml"
           - "/usr/bin/mvn"
           - "install"
+          - "-s"
+          - "/workspace/.m2/settings.xml"
         env:
         - name: MAVEN_OPTS
           value: "-server -Xms256m -Xmx512m -XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
         volumeMounts:
         - name: conf-vol
-          mountPath: /workspace/mvn-config
+          mountPath: /workspace/.m2
         - name: m2-vol
           mountPath: /workspace/.m2/repository
         workingDir: /workspace/source
@@ -40,9 +86,16 @@ tasks:
 
 
 pipelines:
-  - name: geomark-clone-helm
+  - name: geomark-clone-build-helm
     triggerName: geomark-trigger-helm
     bindingName: geomark-binding-helm
+    serviceAccountName:
+      - pipelineTaskName: clone-repo
+        taskServiceAccountName: git-bot
+      - pipelineTaskName: maven-build
+        taskServiceAccountName: pipeline
+      - pipelineTaskName: image-build
+        taskServiceAccountName: pipeline
     pipeline_params:
       - name: git-url
         type: string
@@ -61,9 +114,9 @@ pipelines:
         incomingValue: $(body.pull_request.head.sha)
         resourceTemplate: $(tt.params.git-revision)
     workspaces:
-      - name: output
-        workspace: shared-workspace
+      - name: shared-workspace
         persistentVolumeClaim: pip-tkt-repo-pvc
+      - name: input
     podTemplate:
       securityContext:
         runAsNonRoot: true
@@ -89,6 +142,25 @@ pipelines:
         workspaces:
         - name: source
           workspace: shared-workspace
+
+      - name: image-build
+        ref:
+          name: cli-build-helm
+        runAfter:
+          - maven-build
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+        params:
+          - name: git-tag
+            value: 6.0.x-SNAPSHOT
+            # value: $(params.git-revision)
+          - name: image-tag
+            value: test
+          - name: route-url
+            value: https://geomark-tomcat-f8d638-test.apps.silver.devops.gov.bc.ca/pub/geomark/geomarks/
+          - name: ns
+            value: f8d638-test
 
 events:
   install: true

--- a/charts/tekton-pipelines/examples/open-pr-trigger.yaml
+++ b/charts/tekton-pipelines/examples/open-pr-trigger.yaml
@@ -122,7 +122,7 @@ tasks:
           /usr/bin/mvn versions:set -s /workspace/.m2/settings.xml -DnewVersion=$GIT_REVISION -DgroupId='*' -DgenerateBackupPoms=false
           sed -i "s/__VERSION__mvn/$GIT_REVISION/g" src/docs/*.html
           NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          /usr/bin/mvn install -q -s /workspace/.m2/settings.xml > /workspace/pr/comments/$NOW
+          /usr/bin/mvn install -s /workspace/.m2/settings.xml > /workspace/pr/comments/$NOW
           if [[ "$?" -eq 0 ]] ; then
             rm /workspace/pr/comments/$NOW;
           fi
@@ -199,7 +199,7 @@ pipelines:
           - name: route-url
             value: $(params.route-url)
           - name: ns
-            value: $(params.ns)
+            value: f8d638-dev
     finally:
       - name: free-mutex
         ref:

--- a/charts/tekton-pipelines/examples/open-pr-trigger.yaml
+++ b/charts/tekton-pipelines/examples/open-pr-trigger.yaml
@@ -142,6 +142,26 @@ pipelines:
         default: main
         incomingValue: $(body.pull_request.head.sha)
         resourceTemplate: $(tt.params.git-revision)
+      - name: route-url
+        type: string
+        description: api url subject to testing
+        default: https://geomark-tomcat-f8d638-test.apps.silver.devops.gov.bc.ca/pub/geomark/api/geomarks/
+      - name: git-auth-token
+        description: machine account auth token used for pushing content
+        type: string
+        default: github-auth-token
+      - name: git-tag
+        description: default tag that is build in main
+        type: string
+        default: 6.0.x-SNAPSHOT
+      - name: ns
+        description: namespace used for test deployment
+        type: string
+        default: f8d638-test
+      - name: image-tag
+        description: image deployment trigger tag
+        type: string
+        default: test
     workspaces:
       - name: shared-workspace
         volumeClaimTemplate: 2Gi
@@ -203,14 +223,14 @@ pipelines:
           workspace: shared-workspace
         params:
           - name: git-tag
-            value: 6.0.x-SNAPSHOT
+            value: $(params.git-tag)
             # value: $(params.git-revision)
           - name: image-tag
-            value: test
+            value: $(params.image-tag)
           - name: route-url
-            value: https://geomark-tomcat-f8d638-test.apps.silver.devops.gov.bc.ca/pub/geomark/geomarks/
+            value: $(params.route-url)
           - name: ns
-            value: f8d638-test
+            value: $(params.ns)
       - name: pull-tests
         ref:
           name: git-cli
@@ -238,7 +258,7 @@ pipelines:
           workspace: pr-content
         params:
         - name: api_url
-          value: "https://geomark-tomcat-f8d638-test.apps.silver.devops.gov.bc.ca/pub/geomark/api/geomarks/"
+          value: $(params.route-url)
     finally:
       - name: notify-test-results
         ref:
@@ -251,7 +271,7 @@ pipelines:
         - name: url
           value: $(params.pr-url)
         - name: secret-key-ref
-          value: github-auth-token
+          value: $(params.git-auth-token)
         - name: mode
           value: upload
         - name: provider

--- a/charts/tekton-pipelines/templates/003-tasks.yaml
+++ b/charts/tekton-pipelines/templates/003-tasks.yaml
@@ -58,8 +58,8 @@ spec:
     - name: {{ .name }}
       image: {{ .image }}
       {{ if .script }}
-      script: |
-{{ .script | indent 8 }}
+      script:
+        {{- toYaml .script | indent 8 }}
       {{ else }}
       command:
       {{- range .command }}

--- a/charts/tekton-pipelines/templates/003-tasks.yaml
+++ b/charts/tekton-pipelines/templates/003-tasks.yaml
@@ -25,7 +25,7 @@ spec:
     {{- end -}}
   {{- end -}}
   {{- end }}
-  
+
   {{- if .resources -}}
   {{- if gt (len .resources) 0 }}
   inputs:
@@ -36,7 +36,21 @@ spec:
       {{- end -}}
   {{- end -}}
   {{- end }}
-
+  {{- if .volumes -}}
+  {{ if gt (len .volumes) 0 }}
+  volumes:
+    {{ range .volumes }}
+  - name: {{ .name }}
+    {{ if .persistentVolumeClaim }}
+    persistentVolumeClaim:
+      claimName: {{ .persistentVolumeClaim }}
+    {{ else if .configMap }}
+    configMap:
+      name: {{ .configMap }}
+    {{ end }}
+    {{ end }}
+  {{ end }}
+  {{- end -}}
   {{- if .steps -}}
   {{- if gt (len .steps) 0 }}
   steps:
@@ -47,12 +61,41 @@ spec:
       script: |
 {{ .script | indent 8 }}
       {{ else }}
-      command: 
+      command:
       {{- range .command }}
         - {{ . }}
       {{- end -}}
       {{ end }}
-      env: 
+      {{ if .workingDir }}
+      workingDir: {{ .workingDir }}
+      {{ end }}
+      {{ with .resources }}
+      resources:
+        {{ with .requests }}
+        requests:
+            memory: {{ .memory }}
+            cpu: {{ .cpu }}
+        {{ end }}
+        {{ with .limits }}
+        limits:
+            {{ if .memory }}
+            memory: {{ .memory }}
+            {{ end }}
+            {{ if .cpu }}
+            cpu: {{ .cpu }}
+            {{ end }}
+        {{ end }}
+      {{ end }}
+      {{- if .volumeMounts -}}
+      {{ if gt (len .volumeMounts) 0 }}
+      volumeMounts:
+      {{ range .volumeMounts }}
+      - name: {{ .name }}
+        mountPath: {{ .mountPath }}
+      {{ end }}
+      {{ end }}
+      {{- end -}}
+      env:
       {{- range .env }}
         - name: {{ .name }}
           {{ if .secret }}

--- a/charts/tekton-pipelines/templates/020-pipelines.yaml
+++ b/charts/tekton-pipelines/templates/020-pipelines.yaml
@@ -13,7 +13,7 @@ spec:
 
   workspaces:
     - name: shared-workspace
-    
+
   {{- if .resources -}}
   {{- if gt (len .resources) 0 }}
   resources:
@@ -24,10 +24,10 @@ spec:
   {{- end -}}
   {{- end }}
 
-  {{- if .params -}}
-  {{- if gt (len .params) 0 }}
+  {{- if .pipeline_params -}}
+  {{- if gt (len .pipeline_params) 0 }}
   params:
-    {{- range .params }}
+    {{- range .pipeline_params }}
     - name: {{ .name }}
       type: {{ .type }}
       description: {{ .description }}

--- a/charts/tekton-pipelines/templates/020-pipelines.yaml
+++ b/charts/tekton-pipelines/templates/020-pipelines.yaml
@@ -11,8 +11,14 @@ metadata:
     heritage: {{ $.Release.Service }}
 spec:
 
+  {{- if .workspaces -}}
+  {{ if gt (len .workspaces) 0 }}
   workspaces:
-    - name: shared-workspace
+    {{ range .workspaces }}
+    - name: {{ .workspace }}
+    {{ end }}
+  {{ end }}
+  {{- end -}}
 
   {{- if .resources -}}
   {{- if gt (len .resources) 0 }}

--- a/charts/tekton-pipelines/templates/020-pipelines.yaml
+++ b/charts/tekton-pipelines/templates/020-pipelines.yaml
@@ -15,7 +15,7 @@ spec:
   {{ if gt (len .workspaces) 0 }}
   workspaces:
     {{ range .workspaces }}
-    - name: {{ .workspace }}
+    - name: {{ .name }}
     {{ end }}
   {{ end }}
   {{- end -}}

--- a/charts/tekton-pipelines/templates/020-pipelines.yaml
+++ b/charts/tekton-pipelines/templates/020-pipelines.yaml
@@ -41,7 +41,29 @@ spec:
     {{- end -}}
   {{- end -}}
   {{- end }}
-
+  {{- if .finally -}}
+  {{- if gt (len .finally) 0 }}
+  finally:
+    {{- range .finally }}
+    - name: {{ .name }}
+      taskRef:
+{{ .ref | toYaml | indent 8 }}
+      {{- if .workspaces }}
+      workspaces:
+{{ .workspaces | toYaml | indent 8 }}
+      {{ end }}
+      {{- if .params -}}
+      {{- if gt (len .params) 0 }}
+      params:
+      {{- range .params }}
+      - name: {{ .name }}
+        value: "{{ .value }}"
+      {{ end }}
+      {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+  {{ end }}
   {{- if .tasks -}}
   {{- if gt (len .tasks) 0 }}
   tasks:

--- a/charts/tekton-pipelines/templates/500-triggerTemplate.yaml
+++ b/charts/tekton-pipelines/templates/500-triggerTemplate.yaml
@@ -41,7 +41,7 @@ spec:
             {{ if .persistentVolumeClaim }}
             persistentVolumeClaim:
               claimName: {{ .persistentVolumeClaim }}
-            {{ else if .emptyDir }}
+            {{ else }}
             emptyDir: {}
             {{ end }}
           {{ end }}

--- a/charts/tekton-pipelines/templates/500-triggerTemplate.yaml
+++ b/charts/tekton-pipelines/templates/500-triggerTemplate.yaml
@@ -34,8 +34,28 @@ spec:
           name: {{ .name }}
 
         workspaces:
-          - emptyDir: {}
-            name: shared-workspace
+        {{- if .workspaces -}}
+        {{ if gt (len .workspaces) 0 }}
+          {{ range .workspaces }}
+          - name: {{ .workspace }}
+            {{ if .persistentVolumeClaim }}
+            persistentVolumeClaim:
+              claimName: {{ .persistentVolumeClaim }}
+            {{ else if .emptyDir }}
+            emptyDir: {}
+            {{ end }}
+          {{ end }}
+        {{ end }}
+        {{- end -}}
+
+        {{ with .podTemplate }}
+        podTemplate:
+            {{ with .securityContext }}
+            securityContext:
+                runAsNonRoot: {{ .runAsNonRoot }}
+                runAsUser: {{ .runAsUser }}
+            {{ end }}
+        {{ end }}
 
         {{- if .pipeline_params -}}
         {{- if gt (len .pipeline_params) 0 }}

--- a/charts/tekton-pipelines/templates/500-triggerTemplate.yaml
+++ b/charts/tekton-pipelines/templates/500-triggerTemplate.yaml
@@ -40,6 +40,21 @@ spec:
             {{ if .persistentVolumeClaim }}
             persistentVolumeClaim:
               claimName: {{ .persistentVolumeClaim }}
+            {{ else if .volumeClaimTemplate }}
+            volumeClaimTemplate:
+              metadata:
+                name: pr-pvc
+                labels:
+                  app: {{ template "pipelines.name" $ }}
+                  chart: {{ template "pipelines.chart" $ }}
+                  release: {{ $.Release.Name }}
+                  heritage: {{ $.Release.Service }}
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: {{ .volumeClaimTemplate }}
             {{ else }}
             emptyDir: {}
             {{ end }}

--- a/charts/tekton-pipelines/templates/500-triggerTemplate.yaml
+++ b/charts/tekton-pipelines/templates/500-triggerTemplate.yaml
@@ -10,10 +10,10 @@ metadata:
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
 spec:
-  {{- if .params -}}
-  {{- if gt (len .params) 0 }}
+  {{- if .pipeline_params -}}
+  {{- if gt (len .pipeline_params) 0 }}
   params:
-    {{- range .params }}
+    {{- range .pipeline_params }}
     - name: {{ .name }}
       description: {{ .description }}
       {{- if .default }}
@@ -22,7 +22,7 @@ spec:
     {{- end -}}
   {{- end -}}
   {{- end }}
-  
+
   resourcetemplates:
     - apiVersion: tekton.dev/v1alpha1
       kind: PipelineRun
@@ -32,15 +32,15 @@ spec:
         serviceAccountName: {{ $.Values.serviceAccountName }}
         pipelineRef:
           name: {{ .name }}
-          
+
         workspaces:
           - emptyDir: {}
             name: shared-workspace
 
-        {{- if .params -}}
-        {{- if gt (len .params) 0 }}
+        {{- if .pipeline_params -}}
+        {{- if gt (len .pipeline_params) 0 }}
         params:
-          {{- range .params }}
+          {{- range .pipeline_params }}
           - name: {{ .name }}
             value: {{ .resourceTemplate }}
           {{- end -}}
@@ -67,5 +67,5 @@ spec:
           {{- end -}}
         {{- end -}}
         {{- end -}}
-        
+
 {{ end }}

--- a/charts/tekton-pipelines/templates/500-triggerTemplate.yaml
+++ b/charts/tekton-pipelines/templates/500-triggerTemplate.yaml
@@ -24,12 +24,11 @@ spec:
   {{- end }}
 
   resourcetemplates:
-    - apiVersion: tekton.dev/v1alpha1
+    - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
         name: {{ .name }}-run-$(uid)
       spec:
-        serviceAccountName: {{ $.Values.serviceAccountName }}
         pipelineRef:
           name: {{ .name }}
 
@@ -37,7 +36,7 @@ spec:
         {{- if .workspaces -}}
         {{ if gt (len .workspaces) 0 }}
           {{ range .workspaces }}
-          - name: {{ .workspace }}
+          - name: {{ .name }}
             {{ if .persistentVolumeClaim }}
             persistentVolumeClaim:
               claimName: {{ .persistentVolumeClaim }}
@@ -56,6 +55,16 @@ spec:
                 runAsUser: {{ .runAsUser }}
             {{ end }}
         {{ end }}
+
+        {{- if .serviceAccountName -}}
+        {{- if gt (len .serviceAccountName) 0 }}
+        taskRunSpecs:
+          {{- range .serviceAccountName }}
+          - pipelineTaskName: {{ .pipelineTaskName }}
+            taskServiceAccountName: {{ .taskServiceAccountName }}
+          {{- end -}}
+        {{- end -}}
+        {{- end }}
 
         {{- if .pipeline_params -}}
         {{- if gt (len .pipeline_params) 0 }}

--- a/charts/tekton-pipelines/templates/500-triggerTemplate.yaml
+++ b/charts/tekton-pipelines/templates/500-triggerTemplate.yaml
@@ -86,7 +86,11 @@ spec:
         params:
           {{- range .pipeline_params }}
           - name: {{ .name }}
+            {{ if .resourceTemplate }}
             value: {{ .resourceTemplate }}
+            {{ else if .default }}
+            value: {{ .default }}
+            {{ end }}
           {{- end -}}
         {{- end -}}
         {{- end }}

--- a/charts/tekton-pipelines/templates/505-triggerBinding.yaml
+++ b/charts/tekton-pipelines/templates/505-triggerBinding.yaml
@@ -10,11 +10,11 @@ metadata:
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
 
-{{ if .params }}
-{{ if gt  (len .params) 0}}
+{{ if .pipeline_params }}
+{{ if gt  (len .pipeline_params) 0}}
 spec:
   params:
-  {{ range .params}}
+  {{ range .pipeline_params}}
     - name: {{ .name}}
       value: {{ .incomingValue}}
 

--- a/charts/tekton-pipelines/templates/510-eventBinding.yaml
+++ b/charts/tekton-pipelines/templates/510-eventBinding.yaml
@@ -58,20 +58,34 @@ spec:
                     cpu: "500m"
   triggers:
     {{- range .triggers }}
-    - template:
-        name: {{ .trigger }}
+    - name: {{ .name }}
+      template:
+        ref: {{ .trigger }}
       bindings:
-        - name: {{ .binding }}
-          value: {{ .binding }}
-      # interceptors:
-      #   - ref:
-      #       name: "github"
-      #     params:
-      #       - name: "secretRef"
-      #         value:
-      #           secretName: {{ $.Release.Name }}-tek-github-secret
-      #           secretKey: secretToken
+      - ref: {{ .binding }}
+      {{- if .interceptors -}}
+      {{- if gt (len .interceptors) 0 }}
+      interceptors:
+      {{- range .interceptors }}
+        - {{ .name }}:
+            {{ if .secretName }}
+            secretRef:
+              secretName: {{ .secretName }}
+              secretKey: secretToken
+            {{ end }}
+            {{ if .eventTypes }}
+            {{- if gt (len .eventTypes) 0 }}
+            eventTypes:
+              {{- range .eventTypes }}
+              - {{ .name }}
+              {{- end }}
+            {{- end }}
+            {{ else if .filter }}
+            filter: {{ .filter }}
+            {{ end }}
+      {{- end }}
+      {{- end -}}
+      {{- end }}
     {{- end -}}
-
 {{- end -}}
 {{ end }}

--- a/charts/tekton-pipelines/templates/510-eventBinding.yaml
+++ b/charts/tekton-pipelines/templates/510-eventBinding.yaml
@@ -43,6 +43,7 @@ metadata:
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
 spec:
+  serviceAccountName: pipeline
   resources:
     kubernetesResource:
       spec:

--- a/charts/tekton-pipelines/templates/530-ingress.yaml
+++ b/charts/tekton-pipelines/templates/530-ingress.yaml
@@ -1,15 +1,16 @@
-
-
 {{- if .Values.events.install -}}
 {{range .Values.events.listeners}}
 {{- if .ingress.enabled -}}
 {{ $ingressPath := .ingress.path }}
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
+kind: Route
+apiVersion: route.openshift.io/v1
 metadata:
   name: {{ .ingress.name }}
   labels:
+    app.kubernetes.io/managed-by: EventListener
+    app.kubernetes.io/part-of: Triggers
+    eventlistener: {{ .ingress.name }}
     app: {{ template "pipelines.name" $ }}
     chart: {{ template "pipelines.chart" $ }}
     release: {{ $.Release.Name }}
@@ -18,27 +19,23 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
+  managedFields:
+    - manager: kubectl-expose
+      apiVersion: route.openshift.io/v1
+    - manager: openshift-router
+      apiVersion: route.openshift.io/v1
 spec:
-{{- if .ingress.tls }}
-  tls:
-  {{- range .ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . }}
-      {{- end }}
-      secretName: {{ .secretName }}
-  {{- end }}
-{{- end }}
-  rules:
-  {{ range $i, $host := .ingress.hosts }}
-    - host: {{ $host.name }}
-      http:
-        paths:
-          - path: {{ $ingressPath }}
-            backend:
-              serviceName: {{ $host.service }}
-              servicePort: {{ $host.port }}
-  {{- end }}
+  host: {{ .ingress.host }}
+  to:
+    kind: Service
+    name: {{ .ingress.service }}
+  port:
+    targetPort: http-listener
+status:
+  ingress:
+    - host: {{ .ingress.host }}
+      routerName: default
+      wildcardPolicy: None
 {{ end }}
 {{- end -}}
 {{- end -}}

--- a/charts/tekton-pipelines/templates/configMap.yaml
+++ b/charts/tekton-pipelines/templates/configMap.yaml
@@ -1,0 +1,16 @@
+{{ range .Values.configMaps -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: maven-settings
+  labels:
+    app: {{ template "pipelines.name" $ }}
+    chart: {{ template "pipelines.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+data:
+{{- if .artifactorySettingsXml }}
+   settings.xml:
+{{ .artifactorySettingsXml | toYaml | indent 4}}
+{{ end }}
+{{ end -}}

--- a/charts/tekton-pipelines/templates/pvc.yaml
+++ b/charts/tekton-pipelines/templates/pvc.yaml
@@ -1,0 +1,14 @@
+{{ range .Values.PVCs -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .name }}
+spec:
+  accessModes:
+    - {{ .accessModes }}
+  resources:
+    requests:
+      storage: {{ .storage }}
+  storageClassName: netapp-file-standard
+  volumeMode: {{ .volumeMode }}
+{{ end -}}


### PR DESCRIPTION
…m webhook

1. We need global pipeline parameters that can be set via webhook trigger and shared by the tasks - hence add pipeline_params
https://tekton.dev/docs/pipelines/pipelines/#specifying-parameters

2. We need to bind these parameters to values received from webhook

3. We need to set custom interceptors to filter webhooks

4. Maven build needs more pod resource than default setting, mounting of settings.xml, and pvc volumes (e.g., I have been using a pvc to cache artifactory repo) - hence need to be able to have more customizations for Task objects

5. Added ability to switch service accounts between tasks

6.  I started working on an example - it reacts to open/reopen pull_request gets url/commit sha from the webhook, and passes these to git-clone ClusterTask and does a maven build, then the image is build using .war generated from maven step via ocp cli ClusterTask, it is deployed in test and we subsequently run python integration tests against it with a comment being posted against the PR that contains pytest logs
