### PR TITLE
Update generic-api nginx and oauth2-proxy versions

### DIFF
--- a/charts/generic-api/Chart.yaml
+++ b/charts/generic-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.24
+version: 0.1.25
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/generic-api/values.yaml
+++ b/charts/generic-api/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: nginx
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.18.0"
+  tag: "1.23.2"
 
 imagePullSecrets: []
 
@@ -194,7 +194,7 @@ oauthProxy:
     repository: quay.io/oauth2-proxy/oauth2-proxy
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: v7.1.3
+    tag: v7.4.0
 
   resources:
     requests:


### PR DESCRIPTION
Updates:
nginx: 1.18.0 -> 1.23.2
oauth2-proxy: v7.1.3 -> v7.4.0