### PR TITLE
Add support for custom secrets, default networkpolicy to backup-storage

### DIFF
--- a/charts/backup-storage/Chart.yaml
+++ b/charts/backup-storage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.13
+version: 0.1.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/backup-storage/templates/deployment.yaml
+++ b/charts/backup-storage/templates/deployment.yaml
@@ -70,6 +70,12 @@ spec:
                 secretKeyRef:
                   name: {{ $fullName }}-secrets
                   key: {{ $index | kebabcase }}
+            {{- else if .existingSecret }}
+            - name: {{ $index }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .existingSecret.name }}
+                  key: {{ .existingSecret.key }}
             {{- else }}
             - name: {{ $index }}
               value: {{ .value | quote }}

--- a/charts/backup-storage/templates/networkpolicy.yaml
+++ b/charts/backup-storage/templates/networkpolicy.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: v1
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "backup-storage.fullname" . }}-networkpolicy
+  labels:
+    app: {{ include "backup-storage.name" . }}
+    chart: {{ include "backup-storage.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  description: |
+    Default network policy for {{ include "backup-storage.name" . }}
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels: {{ include "backup-storage.selectorLabels" . | nindent 14 }}
+          namespaceSelector:
+            matchLabels:
+              name: {{ .Release.Namespace }}
+      ports:
+        - protocol: TCP
+          port: {{  .Values.networkPolicy.backupServicePort }}
+  podSelector:
+    matchLabels:
+      {{- with .Values.networkPolicy.selectorLabels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+{{- end -}}

--- a/charts/backup-storage/values.yaml
+++ b/charts/backup-storage/values.yaml
@@ -83,10 +83,11 @@ env:
     value: ""
   ENVIRONMENT_FRIENDLY_NAME:
     value: "Yeah backups"
-  EXISTING_DEPLOYMENT_PASSWORD:
-    existingSecret:
-      name: "existing-secret-name"
-      key: "existing-secret-key"
+  # use the following syntax to wire-up an existing secret
+  # EXISTING_DEPLOYMENT_PASSWORD:
+  #   existingSecret:
+  #     name: "existing-secret-name"
+  #     key: "existing-secret-key"
 
 networkPolicy:
   # If true, a default network policy is created allowing access to matching database services

--- a/charts/backup-storage/values.yaml
+++ b/charts/backup-storage/values.yaml
@@ -83,6 +83,19 @@ env:
     value: ""
   ENVIRONMENT_FRIENDLY_NAME:
     value: "Yeah backups"
+  EXISTING_DEPLOYMENT_PASSWORD:
+    existingSecret:
+      name: "existing-secret-name"
+      key: "existing-secret-key"
+
+networkPolicy:
+  # If true, a default network policy is created allowing access to matching database services
+  enabled: false
+  # Specifies which port the backup container will send requests from
+  backupServicePort: 5432
+  # Labels that must be set on the target databases for the backup service to be able to access them
+  selectorLabels:
+    backup: "true"
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
* Add support for wiring-up existing secrets to environment variables (useful when specifying multiple target databases using `backup.conf`)
* Add a default network policy - disabled by default - that can be used to specify which target services will allow the `backup-storage` access to allow for backups

The network policy is particularly good to have (in my opinion) as it would allow all services with specific labels to be accessible by the backup container, rather than having to roll-out custom network policies for each service requiring backups.