### PR TITLE
[backup-storage] Remove namespaceSelector in network policy

### DIFF
--- a/charts/backup-storage/Chart.yaml
+++ b/charts/backup-storage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.14
+version: 0.1.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/backup-storage/templates/networkpolicy.yaml
+++ b/charts/backup-storage/templates/networkpolicy.yaml
@@ -16,9 +16,6 @@ spec:
     - from:
         - podSelector:
             matchLabels: {{ include "backup-storage.selectorLabels" . | nindent 14 }}
-          namespaceSelector:
-            matchLabels:
-              name: {{ .Release.Namespace }}
       ports:
         - protocol: TCP
           port: {{  .Values.networkPolicy.backupServicePort }}


### PR DESCRIPTION
The namespaceSelector in the network policy template does not work in OpenShift