### PR TITLE
[backup-storage] Remove description field from network policy template

### DIFF
--- a/charts/backup-storage/Chart.yaml
+++ b/charts/backup-storage/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.15
+version: 0.1.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/backup-storage/templates/networkpolicy.yaml
+++ b/charts/backup-storage/templates/networkpolicy.yaml
@@ -10,8 +10,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  description: |
-    Default network policy for {{ include "backup-storage.name" . }}
   ingress:
     - from:
         - podSelector:


### PR DESCRIPTION
The `description` field in NetworkPolicy object is not a valid field in Kubernetes manifests.