### PR TITLE
Allow command and args to be overwritten (to support vault-based secr…

### DIFF
--- a/charts/backup-storage/Chart.yaml
+++ b/charts/backup-storage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.16
+version: 0.1.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.16.0
+appVersion: 1.17.0

--- a/charts/backup-storage/templates/deployment.yaml
+++ b/charts/backup-storage/templates/deployment.yaml
@@ -50,6 +50,15 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.command }}
+          command:
+            {{- toYaml .Values.command | nindent 12 }}
+          {{- end }}
+
+          {{- if .Values.args }}
+          args:
+            {{- toYaml .Values.args | nindent 12 }}
+          {{- end }}
           env:
           {{- with .Values.db }}
             - name: DATABASE_USER

--- a/charts/backup-storage/values.yaml
+++ b/charts/backup-storage/values.yaml
@@ -107,6 +107,14 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+command:
+# override the default command executed by the container (appended to the entrypoint [/tini --]) eg:
+# - . /vault/secrets/my-vault-secret && bash /backup.sh
+
+args:
+# additional arguments for the command, eg:
+# - -1
+
 podAnnotations: {}
 
 podSecurityContext:


### PR DESCRIPTION
…ets).

Allowing the command and args to be overwritten allows vault-based environment variables to be loaded during container initialization.

also removed the empty notes.txt file - appears unused.