### PR TITLE
Cleanup for Vault based emerald projects

### DIFF
--- a/charts/backup-storage/Chart.yaml
+++ b/charts/backup-storage/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.17
+version: 0.1.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.17.0
+appVersion: 1.18.0

--- a/charts/backup-storage/templates/deployment.yaml
+++ b/charts/backup-storage/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
     {{- end }}
       labels:
         {{- include "backup-storage.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -61,6 +64,7 @@ spec:
           {{- end }}
           env:
           {{- with .Values.db }}
+          {{- if .enabled }}
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:
@@ -71,6 +75,7 @@ spec:
                 secretKeyRef:
                   name: {{ .secretName }}
                   key: {{ .passwordKey }}
+          {{- end }}
           {{- end }}
           {{- range $index, $val := .Values.env }}
             {{- if .secure }}

--- a/charts/backup-storage/templates/secret.yaml
+++ b/charts/backup-storage/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.db.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,3 +15,4 @@ data:
   {{ $index | kebabcase }}: {{ .value | b64enc | quote }}
   {{ end }}
 {{ end }}
+{{- end }}

--- a/charts/backup-storage/values.yaml
+++ b/charts/backup-storage/values.yaml
@@ -119,6 +119,9 @@ args:
 
 podAnnotations: {}
 
+# Labels to be added to deployment pods. (ie. "DataClass: Medium" for emerald)
+podLabels:
+
 podSecurityContext:
   {}
   # fsGroup: 2000

--- a/charts/backup-storage/values.yaml
+++ b/charts/backup-storage/values.yaml
@@ -41,6 +41,8 @@ db:
   secretName: "patroni"
   usernameKey: "username-superuser"
   passwordKey: "password-superuser"
+  # allow kube secret auth to be disabled - in case of vault or other secret injection
+  enabled: true
 
 env:
   BACKUP_STRATEGY:


### PR DESCRIPTION
1. Allow emerald projects to add required podLabels via values.
2. Allow vault projects to disable default kube secrets auth (not strictly required but prevents unused secret/env vars from being created).